### PR TITLE
Add jekyll-include-cache gem

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ sass:
 
 markdown: kramdown
 plugins:
+  - jekyll-include-cache
   - jekyll-sitemap
 exclude:
   - Gemfile

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,9 +2,13 @@
   <div class="inner">
     <ul id="socials">
       {%- for social in site.data.socials -%}
-      <li><a href="{{ social.url }}" title="{{ social.name }}" rel="me" target="_blank">{% include icons/{{ social.icon }} %}<span class="sr-only">{{ social.name }}</span></a></li>{%- endfor -%}
+      <li><a href="{{ social.url }}" title="{{ social.name }}" rel="me" target="_blank">{% include_cached icons/{{ social.icon }} %}<span class="sr-only">{{ social.name }}</span></a></li>{%- endfor -%}
     </ul>
-    {% capture license %}{% include icons/creative-commons.svg size="24" %}{% include icons/creative-commons-by.svg size="24" %}{% include icons/creative-commons-sa.svg size="24" %}{% endcapture %}
+    {% capture license %}
+    {% include_cached icons/creative-commons.svg size="24" %}
+    {% include_cached icons/creative-commons-by.svg size="24" %}
+    {% include_cached icons/creative-commons-sa.svg size="24" %}
+    {% endcapture %}
     <hr/>
     <div id="bottom-footer">
       <span>Copyright &copy; 1998-{{ site.time | date: "%Y" }} bugzilla.org contributors</span>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  {% include head.html %}
+  {% include_cached head.html %}
   <body id="www-bugzilla-org" class="homepage">
-    {% include header.html %}
+    {% include_cached header.html %}
     <main>
       {{ content }}
     </main>
-    {% include footer.html %}
+    {% include_cached footer.html %}
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: base
   <div class="card">
     <p class="date muted">{{ page.date | date: '%d. %B %Y' }}</p>
     <h1 class="title">{{ page.title }}</h1>
-    {% include authors.html authors=page.author %}
+    {% include_cached authors.html authors=page.author %}
     {{ content }}
   </div>
 </div>


### PR DESCRIPTION
This patch enable build caching by using the jekyll-include-cache gem available in github-pages. You can now use `{% include_cached PATH PARAMS %}` instead of the default include function. With this change, the build time was reduced by around 40%. 

