### PR TITLE
Explicitly pass page variable to the include_cached file

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,28 +1,28 @@
 <head>
   {%- assign title = site.title -%}
-  {% if page.title %}
-    {%- assign title = page.title -%}
+  {% if include.page.title %}
+    {%- assign title = include.page.title -%}
   {%- endif -%}
   {%- capture image %}{{ site.url }}/assets/img/banner.png{% endcapture -%}
-  {% if page.image %}
-    {% if page.ogtype == "profile" %}
-      {%- capture image %}{{ site.url }}/assets/img/developers/{{ page.image }}{% endcapture -%}
+  {% if include.page.image %}
+    {% if include.page.ogtype == "profile" %}
+      {%- capture image %}{{ site.url }}/assets/img/developers/{{ include.page.image }}{% endcapture -%}
     {% else %}
-      {%- capture image %}{{ site.url }}{{ page.image }}{% endcapture %}
+      {%- capture image %}{{ site.url }}{{ include.page.image }}{% endcapture %}
     {% endif %}
   {%- endif -%}
   {% assign description = site.description %}
-  {% if page.content != "" %}
-    {% assign description = page.content | markdownify | strip_html | normalize_whitespace | truncate: 145 %}
+  {% if include.page.content != "" %}
+    {% assign description = include.page.content | markdownify | strip_html | normalize_whitespace | truncate: 145 %}
   {% endif %}
-  {% if page.intro %}
-    {% assign description = page.intro %}
+  {% if include.page.intro %}
+    {% assign description = include.page.intro %}
   {% endif %}
-  {% if page.ogtype == "profile" %}
-    {% capture description %}{% if page.former %}Former {% endif %}{{ page.role }}{% endcapture %}
+  {% if include.page.ogtype == "profile" %}
+    {% capture description %}{% if include.page.former %}Former {% endif %}{{ include.page.role }}{% endcapture %}
   {% endif %}
-  {%- capture canonical %}{{ site.url }}{{ page.url | replace:'index.html',''}}{% endcapture %}
-  <title>{% if page.title != True %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {%- capture canonical %}{{ site.url }}{{ include.page.url | replace:'index.html',''}}{% endcapture %}
+  <title>{% if include.page.title != True %}{{ include.page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="keywords" content="bugzilla bug track tracking enterprise solution">
@@ -30,7 +30,7 @@
   <link rel="stylesheet" type="text/css" href="/assets/css/global.css">
   <link rel="stylesheet" type="text/css" href="/assets/css/addon.css">
   <script defer src="/assets/js/global.js"></script>
-  {% for addon in page.addons %}
+  {% for addon in include.page.addons %}
     {% case addon.type %}
     {% when 'js' %}
       <script defer src="{{ addon.link }}"></script>
@@ -38,28 +38,28 @@
       <link defer rel="stylesheet" type="text/css" href="{{ addon.link }}" {% if addon.media %}media="{{ addon.media }}"{% endif %}>
     {% endcase %}
   {% endfor %}
-  {% for meta in page.meta %}
+  {% for meta in include.page.meta %}
     <{{ meta.type }} {{ meta.tags }}>
   {% endfor %}
   <link color="#9248c8" href="/assets/favicon/mask-icon.svg" rel="mask-icon">
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:description" content="{{ description }}" />
-  <meta property="og:type" content="{% if page.ogtype %}{{ page.ogtype }}{% else %}website{% endif %}">
-  {%- case page.ogtype -%}
+  <meta property="og:type" content="{% if include.page.ogtype %}{{ include.page.ogtype }}{% else %}website{% endif %}">
+  {%- case include.page.ogtype -%}
   {%- when "article" %}
-    <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
-    {% for author in page.author -%}
+    <meta property="article:published_time" content="{{ include.page.date | date_to_xmlschema }}">
+    {% for author in include.page.author -%}
     <meta property="article:author" content="{{ site.url }}/developers/{{ author }}">
     {%- endfor %}
-    {% for tag in page.tags -%}
+    {% for tag in include.page.tags -%}
     <meta property="article:tag" content="{{ tag }}">
     {%- endfor %}
-    <meta property="article:section" content="{{ page.categories | first }}">
+    <meta property="article:section" content="{{ include.page.categories | first }}">
   {%- when "profile" %}
-    <meta property="profile:first_name" content="{{ page.firstname }}">
-    <meta property="profile:last_name" content="{{ page.lastname }}">
-    <meta property="profile:username" content="{{ page.nickname }}">
+    <meta property="profile:first_name" content="{{ include.page.firstname }}">
+    <meta property="profile:last_name" content="{{ include.page.lastname }}">
+    <meta property="profile:username" content="{{ include.page.nickname }}">
   {%- endcase %}
   <meta property="og:image" content="{{ image }}">
   <meta property="og:url" content="{{ canonical }}">
@@ -69,7 +69,7 @@
   <meta name="twitter:url" content="{{ canonical }}">
   <meta name="twitter:image" content="{{ image }}">
   <meta name="twitter:site" content="@bugzilla"/>
-  <meta name="twitter:creator" content="{% if page.twitter %}{{ page.twitter }}{% else %}@bugzilla{% endif %}"/>
+  <meta name="twitter:creator" content="{% if include.page.twitter %}{{ include.page.twitter }}{% else %}@bugzilla{% endif %}"/>
   <meta name="theme-color" content="#9248c8">
 
   <link rel="canonical" href="{{ canonical }}">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  {% include_cached head.html %}
+  {% include_cached head.html page=page %}
   <body id="www-bugzilla-org" class="homepage">
     {% include header.html %}
     {% include socials.html %}


### PR DESCRIPTION
See: https://github.com/benbalter/jekyll-include-cache?tab=readme-ov-file#one-potential-gotcha

Since the information inside a include_cached has been... cached, we need to explicitly pass the page variable from layout to make sure we're using the updated version.