### PR TITLE
Fix social widget overlapping content

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -56,6 +56,7 @@
           </li>
           {% endif %}
         {% endfor %}
+        {% if site.data.socials %}
         <li class="dropdown">
           <a
             class="dropdown-toggle"
@@ -75,6 +76,7 @@
             {% endfor %}
           </div>
         </li>
+        {% endif %}
       </ul>
       <form role="search" method="get" action="https://www.google.com/cse">
         <span class="sr-only">Search bugzilla.org</span>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -56,6 +56,25 @@
           </li>
           {% endif %}
         {% endfor %}
+        <li class="dropdown">
+          <a
+            class="dropdown-toggle"
+            href="#"
+            role="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false">
+            Follow Us
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            {% for social in site.data.socials %}
+            <a class="socials" href="{{ social.url }}">
+              {% include icons/{{ social.icon }} %}
+              {{ social.name }}
+            </a>
+            {% endfor %}
+          </div>
+        </li>
       </ul>
       <form role="search" method="get" action="https://www.google.com/cse">
         <span class="sr-only">Search bugzilla.org</span>

--- a/_sass/_app.scss
+++ b/_sass/_app.scss
@@ -6,12 +6,15 @@
 @use "base/reset";
 @use "base/variables";
 @use "base/fonts";
-@use "base/_base";
+@use "base/base";
 
 /* Atoms */
 @use "components/button";
 
 /* Molecules */
+@use "components/breadcrumb";
+@use "components/pagination";
+@use "components/table";
 @use "components/card";
 @use "components/widget";
 @use "components/form";

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -66,6 +66,12 @@
   margin: 0;
 }
 
+#navbar-nav li a.socials {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
 #navbar-nav li a {
   padding: 8px;
   color: var(--application-header-foreground-color);

--- a/_sass/components/_widget.scss
+++ b/_sass/components/_widget.scss
@@ -42,3 +42,9 @@
     }
   }
 }
+
+@media screen and (width < 1200px) {
+  #widget-socials-container {
+    display: none;
+  }
+}


### PR DESCRIPTION
As discussed in #infrastructure, the social widget was overlapping part of the content. To fix it, I added a rule to hide the widget on screen smaller than 1200px. I also added a menu "Follow Us" in the offcanvas menu.