### PR TITLE
Fix follow us dropdown menu when light mode is enabled

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -69,7 +69,7 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             {% for social in site.data.socials %}
-            <a class="socials" href="{{ social.url }}">
+            <a class="dropdown-item socials" href="{{ social.url }}">
               {% include icons/{{ social.icon }} %}
               {{ social.name }}
             </a>

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -74,7 +74,6 @@
 
 #navbar-nav li a {
   padding: 8px;
-  color: var(--application-header-foreground-color);
   text-decoration: none;
   display: block;
 }


### PR DESCRIPTION
Set the right color for the items in the dropdown menu when the light mode is enabled.

<img width="1605" height="778" alt="image" src="https://github.com/user-attachments/assets/a6068784-aa79-4ad3-adbf-c23d9929b583" />
