### PR TITLE
Fix navbar link color

### DIFF
--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -73,6 +73,7 @@
 }
 
 #navbar-nav li a {
+  color: var(--application-header-foreground-color);
   padding: 8px;
   text-decoration: none;
   display: block;


### PR DESCRIPTION
Navbar links aren't styled correctly expect on the homepage. This issue because a rule was accidentally removed in a previous patch (PR#22).

<img width="1567" height="76" alt="image" src="https://github.com/user-attachments/assets/356d28ee-9981-4fe6-a9c0-86ccc59775ee" />

<img width="1584" height="72" alt="image" src="https://github.com/user-attachments/assets/2817ad85-e64c-49dc-b333-67c5ae1a098c" />

